### PR TITLE
todoServiceのテストでエラーが出ているので修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "docker:down": "docker-compose -f ./docker/docker-compose.yml -p qin-todo down",
     "docker:reset": "yarn docker:down && yarn docker:up",
     "migrate": "yarn prisma db push && npx ts-node prisma/seed/start.ts",
-    "test": "yarn docker:reset && sleep 10 && yarn migrate && jest",
-    "test:watch": "yarn docker:reset && sleep 10 && yarn migrate && jest --watch",
-    "test:cov": "yarn docker:reset && sleep 10 && yarn migrate && jest --coverage",
+    "test": "yarn migrate && jest --runInBand",
+    "test:watch": "jest --watch --runInBand",
+    "test:cov": "jest --coverage --runInBand",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "yarn docker:reset && sleep 10 && yarn migrate && jest --config ./test/jest-e2e.json"
+    "test:e2e": "yarn migrate && jest --config ./test/jest-e2e.json"
   },
   "prisma": {
     "seed": "ts-node prisma/seed/start.ts"

--- a/src/api/todo/todo.controller.spec.ts
+++ b/src/api/todo/todo.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma.service';
+import { UserModule } from '../user/user.module';
 import { TodoController } from './todo.controller';
 import { TodoService } from './todo.service';
 
@@ -8,6 +9,7 @@ describe('TodoController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [UserModule],
       controllers: [TodoController],
       providers: [TodoService, PrismaService],
     }).compile();

--- a/src/common/helper/resetDatabase.ts
+++ b/src/common/helper/resetDatabase.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+import { todo } from '../../../prisma/seed/todo';
+import { todoOrder } from '../../../prisma/seed/todoOrder';
+import { user } from '../../../prisma/seed/user';
+
+const prisma = new PrismaClient();
+const DB_NAME = 'qin-todo';
+export const resetDatabase = async (): Promise<void> => {
+  // table一覧取得
+  const query = `SELECT TABLE_NAME as tableName FROM information_schema.TABLES WHERE TABLE_SCHEMA = \"${DB_NAME}\"`;
+  const tableNames = (
+    (await prisma.$queryRawUnsafe(`${query}`)) as {
+      tableName: string;
+    }[]
+  ).map((table) => table.tableName);
+
+  await prisma.$transaction(async (prisma) => {
+    // foreign keyを解除して、テーブルを削除
+    await prisma.$queryRawUnsafe(`SET FOREIGN_KEY_CHECKS = 0`);
+    tableNames.forEach(
+      async (tableName) =>
+        await prisma.$queryRawUnsafe(`TRUNCATE TABLE ${tableName}`),
+    );
+    await prisma.$queryRawUnsafe(`SET FOREIGN_KEY_CHECKS = 1`);
+  });
+  // データを入れ直す
+  await user();
+  await todo();
+  await todoOrder();
+};


### PR DESCRIPTION
## 変更の概要

- DBの内容をリセットするhelperを追加
- todoServiceの各テスト前にDBリセットを行うhelperを実行
- todoController.specでUserModuleのimportを追加

## なぜこの変更をするのか

- テストが正しく実行されるようにする
- 各テストの内容が実行順に関係なく評価できるようになる
- `prisma migrate reset`や`prisma db push`をすると動作が不安定でテストが成功したり、失敗したりするのが修正される

## 技術的な変更内容

- resetDatabaseヘルパーを追加（table内容を読み取りtableの内容を削除）
- 各テスト前にresetDatabaseを実行
- testスクリプト実行時にdocker を作り直す必要がなくなったので、修正（テスト実行時のパフォーマンス改善）

## どうやるのか（バグ修正の場合などの再現手順）

1. `yarn docker:up`でコンテナ起動
2. `yarn test`でテストを実行