### PR TITLE
Feature/user controller test

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docker:reset": "yarn docker:down && yarn docker:up",
     "migrate": "yarn prisma db push && npx ts-node prisma/seed/start.ts",
     "test": "yarn migrate && jest --runInBand",
-    "test:watch": "jest --watch --runInBand",
+    "test:watch": "jest --watch --runInBand --no-cache",
     "test:cov": "jest --coverage --runInBand",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "yarn migrate && jest --config ./test/jest-e2e.json"

--- a/src/api/user/__mocks__/user.service.ts
+++ b/src/api/user/__mocks__/user.service.ts
@@ -3,5 +3,5 @@ import { userStub } from '../test/stubs/user.stub';
 export const UserService = jest.fn().mockReturnValue({
   updateUser: jest.fn().mockResolvedValue(userStub()),
   uploadAvatarImage: jest.fn().mockResolvedValue(userStub()),
-  deleteUser: jest.fn().mockResolvedValue(userStub()),
+  deleteUser: jest.fn().mockResolvedValue(undefined),
 });

--- a/src/api/user/__mocks__/user.service.ts
+++ b/src/api/user/__mocks__/user.service.ts
@@ -1,7 +1,10 @@
-import { userStub } from '../test/stubs/user.stub';
+import {
+  updatedUserStub,
+  updatedAvatarImageStub,
+} from '../test/stubs/user.stub';
 
 export const UserService = jest.fn().mockReturnValue({
-  updateUser: jest.fn().mockResolvedValue(userStub()),
-  uploadAvatarImage: jest.fn().mockResolvedValue(userStub()),
+  updateUser: jest.fn().mockResolvedValue(updatedUserStub()),
+  uploadAvatarImage: jest.fn().mockResolvedValue(updatedAvatarImageStub()),
   deleteUser: jest.fn().mockResolvedValue(undefined),
 });

--- a/src/api/user/__mocks__/user.service.ts
+++ b/src/api/user/__mocks__/user.service.ts
@@ -1,0 +1,7 @@
+import { userStub } from '../test/stubs/user.stub';
+
+export const UserService = jest.fn().mockReturnValue({
+  updateUser: jest.fn().mockResolvedValue(userStub()),
+  uploadAvatarImage: jest.fn().mockResolvedValue(userStub()),
+  deleteUser: jest.fn().mockResolvedValue(userStub()),
+});

--- a/src/api/user/test/stubs/user.stub.ts
+++ b/src/api/user/test/stubs/user.stub.ts
@@ -1,0 +1,20 @@
+import { User } from '@prisma/client';
+
+/**
+ * Objectで作成してしまうと、どこかでmutateされた場合、
+ * 予測不能な振る舞いを起こす可能性があるので関数で定義する。
+ * userStub関数を呼び出すたびに新しいユーザーが提供される。
+ * その新たに提供されたユーザーは他のtestでは共有されない。
+ */
+export const userStub = (): User => {
+  return {
+    id: 'eb14ff64-a2c2-4455-0da5-c3c1e575cd62',
+    uid: 'ofKQXPnq0VUwk0r15tHcvHXVTrad',
+    username: 'John Conner',
+    email: 'john@skynet.com',
+    avatarUrl:
+      'https://gravatar.com/avatar/3cb5628734a944573d67a5871b1dcbfb?s=400&d=robohash&r=x',
+    createdAt: new Date('2020-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2020-06-01T00:00:00.000Z'),
+  };
+};

--- a/src/api/user/test/stubs/user.stub.ts
+++ b/src/api/user/test/stubs/user.stub.ts
@@ -18,3 +18,29 @@ export const userStub = (): User => {
     updatedAt: new Date('2020-06-01T00:00:00.000Z'),
   };
 };
+
+export const updatedUserStub = (): User => {
+  return {
+    id: 'eb14ff64-a2c2-4455-0da5-c3c1e575cd62',
+    uid: 'ofKQXPnq0VUwk0r15tHcvHXVTrad',
+    username: 'updated username',
+    email: 'john@skynet.com',
+    avatarUrl:
+      'https://gravatar.com/avatar/3cb5628734a944573d67a5871b1dcbfb?s=400&d=robohash&r=x',
+    createdAt: new Date('2020-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2020-06-01T00:00:00.000Z'),
+  };
+};
+
+export const updatedAvatarImageStub = (): User => {
+  return {
+    id: 'eb14ff64-a2c2-4455-0da5-c3c1e575cd62',
+    uid: 'ofKQXPnq0VUwk0r15tHcvHXVTrad',
+    username: 'John Conner',
+    email: 'john@skynet.com',
+    avatarUrl:
+      'https://gravatar.com/avatar/updated3cb5628734a944573d67a587asdfasdfafb?s=400&d=robohash&r=x',
+    createdAt: new Date('2020-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2020-06-01T00:00:00.000Z'),
+  };
+};

--- a/src/api/user/test/user.controller.spec.ts
+++ b/src/api/user/test/user.controller.spec.ts
@@ -102,7 +102,7 @@ describe('UserController', () => {
               req.files = [
                 {
                   originalname: 'sample.name',
-                  mimetype: 'sample.type',
+                  mimetype: 'image/png',
                   path: 'sample.url',
                   buffer: Buffer.from('whatever'),
                 },

--- a/src/api/user/test/user.controller.spec.ts
+++ b/src/api/user/test/user.controller.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from 'src/api/user/user.service';
+import { AuthenticateGuard } from 'src/common/guards/authenticate/authenticate.guard';
+import { PrismaService } from 'src/prisma.service';
+import { CloudStorageService } from '../../cloud-storage/cloud-storage.service';
+import { UserController } from '../user.controller';
+
+/**
+ * jestにuserServiceをmockすることを伝えると、自動的にspy.onされてるらしい。
+ * 通常のuserServiceの代わりに__mocks__内のuserServiceが使われる。
+ */
+jest.mock('../user.service.ts');
+
+// UserControllerのテスト
+describe('UserController', () => {
+  let controller: UserController;
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [
+        UserService,
+        PrismaService,
+        CloudStorageService,
+        {
+          provide: AuthenticateGuard,
+          useValue: jest.fn().mockImplementation(() => true),
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+    service = module.get<UserService>(UserService);
+    // mockをクリアする
+    jest.clearAllMocks();
+  });
+
+  // controllerインスタンス作成のテスト
+  it('can create an instance of user controller', async () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/api/user/test/user.controller.spec.ts
+++ b/src/api/user/test/user.controller.spec.ts
@@ -70,16 +70,16 @@ describe('UserController', () => {
         updateUserDto = {
           username: 'Jane Smith',
         };
+      });
+
+      // controllerで呼び出しているuserServiceのupdateUserが引数(userId, paramUserId, createUserDto)で呼ばれたか確認
+      it('should call userService', async () => {
         user = await controller.updateUser(
           userStub(),
           userStub().id,
           updateUserDto,
         );
-      });
-
-      // controllerで呼び出しているuserServiceのupdateUserが引数(userId, paramUserId, createUserDto)で呼ばれたか確認
-      it('should call userService', () => {
-        expect(service.updateUser).toBeCalledWith(
+        expect(await service.updateUser).toBeCalledWith(
           userStub().id,
           userStub().id,
           updateUserDto,
@@ -87,7 +87,12 @@ describe('UserController', () => {
       });
 
       // 戻り値がuserであるか確認
-      it('then it should return a user', () => {
+      it('then it should return a user', async () => {
+        user = await controller.updateUser(
+          userStub(),
+          userStub().id,
+          updateUserDto,
+        );
         expect(user).toEqual(userStub());
       });
     });
@@ -151,12 +156,12 @@ describe('UserController', () => {
   describe('delete', () => {
     describe('when delete is called', () => {
       beforeEach(async () => {
-        await service.deleteUser(userStub().id);
+        await controller.delete(userStub());
       });
 
       // 戻り値がundefinedであるか確認
       it('then it should be undefined', async () => {
-        expect(await controller.delete(userStub())).toBeUndefined();
+        expect(await service.deleteUser(userStub().id)).toBeUndefined();
       });
 
       // controllerで呼び出しているuserServiceのupdateUserが引数(userId)で呼ばれたか確認

--- a/src/api/user/test/user.controller.spec.ts
+++ b/src/api/user/test/user.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { User } from '@prisma/client';
 import { UserService } from 'src/api/user/user.service';
 import { AuthenticateGuard } from 'src/common/guards/authenticate/authenticate.guard';
 import { PrismaService } from 'src/prisma.service';
 import { CloudStorageService } from '../../cloud-storage/cloud-storage.service';
+import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserController } from '../user.controller';
+import { userStub } from './stubs/user.stub';
 
 /**
  * jestにuserServiceをmockすることを伝えると、自動的にspy.onされてるらしい。
@@ -39,5 +42,127 @@ describe('UserController', () => {
   // controllerインスタンス作成のテスト
   it('can create an instance of user controller', async () => {
     expect(controller).toBeDefined();
+  });
+
+  // usersのテスト
+  describe('users', () => {
+    describe('when users is called', () => {
+      let user: User;
+
+      beforeEach(async () => {
+        user = await controller.users(userStub());
+      });
+
+      // 戻り値がuserであるか確認
+      it('then it should return a user', () => {
+        expect(user).toEqual(userStub());
+      });
+    });
+  });
+
+  // updateUserのテスト
+  describe('updateUser', () => {
+    describe('then it when updateUser is called', () => {
+      let user: User;
+      let updateUserDto: UpdateUserDto;
+
+      beforeEach(async () => {
+        updateUserDto = {
+          username: 'Jane Smith',
+        };
+        user = await controller.updateUser(
+          userStub(),
+          userStub().id,
+          updateUserDto,
+        );
+      });
+
+      // controllerで呼び出しているuserServiceのupdateUserが引数(userId, paramUserId, createUserDto)で呼ばれたか確認
+      it('should call userService', () => {
+        expect(service.updateUser).toBeCalledWith(
+          userStub().id,
+          userStub().id,
+          updateUserDto,
+        );
+      });
+
+      // 戻り値がuserであるか確認
+      it('then it should return a user', () => {
+        expect(user).toEqual(userStub());
+      });
+    });
+  });
+
+  // updateAvatarのテスト
+  describe('updateAvatar', () => {
+    describe('when updateAvatar is called', () => {
+      let user: User;
+      let avatarImage: Express.Multer.File;
+      let multer;
+
+      // アップデートファイルのmockを作成
+      jest.mock('multer', () => {
+        multer = () => ({
+          any: () => {
+            return (req, _res, next) => {
+              req.body = { userName: 'testUser' };
+              req.files = [
+                {
+                  originalname: 'sample.name',
+                  mimetype: 'sample.type',
+                  path: 'sample.url',
+                  buffer: Buffer.from('whatever'),
+                },
+              ];
+              return next();
+            };
+          },
+        });
+        multer.memoryStorage = () => jest.fn();
+        return multer;
+      });
+
+      beforeEach(async () => {
+        avatarImage = multer;
+        user = await controller.updateAvatar(
+          userStub(),
+          userStub().id,
+          avatarImage,
+        );
+      });
+
+      // controllerで呼び出しているuserServiceのuploadAvatarImageが引数(userId, paramUserId, createUserDto)で呼ばれたか確認
+      it('then it should call userService', () => {
+        expect(service.uploadAvatarImage).toBeCalledWith(
+          userStub().id,
+          userStub().id,
+          avatarImage,
+        );
+      });
+
+      // 戻り値がuserであるか確認
+      it('then it should return a user', () => {
+        expect(user).toEqual(userStub());
+      });
+    });
+  });
+
+  // deleteのテスト
+  describe('delete', () => {
+    describe('when delete is called', () => {
+      beforeEach(async () => {
+        await service.deleteUser(userStub().id);
+      });
+
+      // 戻り値がundefinedであるか確認
+      it('then it should be undefined', async () => {
+        expect(await controller.delete(userStub())).toBeUndefined();
+      });
+
+      // controllerで呼び出しているuserServiceのupdateUserが引数(userId)で呼ばれたか確認
+      it('then it should call userService', () => {
+        expect(service.deleteUser).toBeCalledWith(userStub().id);
+      });
+    });
   });
 });

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -28,7 +28,6 @@ export class UserController {
    * GET /api/v1/users
    * ユーザー情報を返す
    */
-
   @Version('1')
   @Get()
   async users(@GetCurrentUser() user: User): Promise<User> {
@@ -39,7 +38,6 @@ export class UserController {
    * PUT /api/v1/users/:userId
    * ユーザー名を更新する
    */
-
   @Version('1')
   @Put(':userId')
   async updateUser(
@@ -54,7 +52,6 @@ export class UserController {
    * PUT /api/v1/users/:userId/avatar
    * アバター画像を更新する
    */
-
   @Version('1')
   @Put(':userId/avatar')
   @UseInterceptors(FileInterceptor('file', multerOptions))


### PR DESCRIPTION
## 変更の概要

- user controller の testを追加

## なぜこの変更をするのか

- テストコードを実装することで、リファクタ・コード修正時のミスを無くすため
- テストコードがが無いと、後々仕様なのか実装ミスなのかがわからなくなるため

## 技術的な変更内容

- [x] userServiceのmockを作成
- [x] テスト用データ、userStub()を作成
オブジェクトで作成すると、どこかで変更された場合予測不能な振る舞いを起こす可能性があるため関数で定義する

## どうやるのか（バグ修正の場合などの再現手順）

1. dockerデーモンを起動
2. `yarn docker:up`
3. `yarn test`をしてテストが通ることを確認

## 課題

- 異常系のテストが未実装