### PR TITLE
Feature/Cascading delete

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,7 @@ model Todo {
   content   String     @db.VarChar(255)
   createdAt DateTime   @default(now()) @map("created_at")
   updatedAt DateTime   @default(now()) @updatedAt @map("updated_at")
-  User      User       @relation(fields: [userId], references: [id])
+  User      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("todo")
 }
@@ -40,7 +40,7 @@ model TodoOrder {
   userId  String
   status  TodoStatus
   todoIds String?    @db.VarChar(1000)
-  User    User       @relation(fields: [userId], references: [id])
+  User    User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, status])
   @@map("todo_order")

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -83,16 +83,8 @@ export class UserService {
   }
 
   async deleteUser(userId: string): Promise<void> {
-    await this.prisma.$transaction(async (prisma) => {
-      await prisma.todoOrder.deleteMany({
-        where: { userId },
-      });
-      await prisma.todo.deleteMany({
-        where: { userId },
-      });
-      await prisma.user.delete({
-        where: { id: userId },
-      });
+    await this.prisma.user.delete({
+      where: { id: userId },
     });
   }
 }

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -13,30 +13,9 @@ export class UserService {
     private readonly cloudStorageService: CloudStorageService,
   ) {}
 
-  async createUser(createUserDto: CreateUserDto): Promise<User> {
-    return await this.prisma.user.create({
-      data: {
-        uid: createUserDto.uid,
-        username: createUserDto.name,
-        email: createUserDto.email,
-        avatarUrl: createUserDto.avatarUrl,
-      },
-    });
-  }
-
   async findUserByUid(uid: string): Promise<User> {
     return await this.prisma.user.findUnique({
       where: { uid },
-    });
-  }
-
-  async createTodoOrder(user): Promise<void> {
-    await this.prisma.todoOrder.createMany({
-      data: [
-        { userId: user.id, status: TodoStatus.TODAY },
-        { userId: user.id, status: TodoStatus.TOMORROW },
-        { userId: user.id, status: TodoStatus.NEXT },
-      ],
     });
   }
 


### PR DESCRIPTION
## 変更の概要

- ユーザー削除時に、関連するデータをCascading deleteで削除する
- 未使用のメソッドを削除

## なぜこの変更をするのか

現状はトランザクションを用い、関連するデータを順番に削除しているが
記述が助長のためCascading deleteでの実装に変更する。

## 技術的な変更内容

- [x] deleteUser内のトランザクションを削除
- [x] prisma schemaのTodo modelとTodoOrder modelに `onDelete:Cascade` を追加

Close #57 